### PR TITLE
Include token.h in `make install`-ed headers

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -42,7 +42,6 @@ SET(HEADER
     client/InputStream.h
     client/OutputStream.h
     client/Permission.h
-    client/Token.h
     common/Exception.h
     common/XmlConfig.h)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -42,6 +42,7 @@ SET(HEADER
     client/InputStream.h
     client/OutputStream.h
     client/Permission.h
+    client/Token.h
     common/Exception.h
     common/XmlConfig.h)
 

--- a/src/client/FileSystem.cpp
+++ b/src/client/FileSystem.cpp
@@ -34,6 +34,7 @@
 #include "Hash.h"
 #include "SessionConfig.h"
 #include "Thread.h"
+#include "Token.h"
 #include "Unordered.h"
 #include "WritableUtils.h"
 

--- a/src/client/FileSystem.h
+++ b/src/client/FileSystem.h
@@ -34,7 +34,6 @@
 #include "FileSystemStats.h"
 #include "Permission.h"
 #include "XmlConfig.h"
-#include "Token.h"
 
 #include <vector>
 


### PR DESCRIPTION
When running `make install` and trying out Filesystem.h ; noticed that Token.h wasn't included in the distribution; so added it to the makefile.