### PR TITLE
Don't scan through entire block for all intra-block seeks.

### DIFF
--- a/src/client/InputStreamImpl.cpp
+++ b/src/client/InputStreamImpl.cpp
@@ -740,7 +740,14 @@ void InputStreamImpl::seekInternal(int64_t pos) {
     }
 
     try {
-        if (blockReader && pos > cursor && pos < endOfCurBlock) {
+        if (blockReader && pos > cursor && pos < endOfCurBlock &&
+                (pos - cursor) < blockReader->available()) {
+
+            /*
+             * If this seek is to a positive position in the current block, and
+             * this piece of data might already be lying in the TCP buffer, then
+             * just eat up the intervening data.
+             */
             blockReader->skip(pos - cursor);
             cursor = pos;
             return;


### PR DESCRIPTION
Previously, when seeking further in the same block, libhdfs3 would
scan all data content between current offset and to-be-seeked offset
to avoid issuing a new RPC call for short seeks. But an intra-block
seek can still be a substantial amount of data and require many
requests.

The native java client uses a more optimal method: it only scans when
the to-be-seeked offset lies in the socket buffer; otherwise it will
send a new OpReadBlockProto RPC call. Update libhdfs3 to use this
superior method.

From original patch by Van Zhong.